### PR TITLE
Changing from the `browserTag` to `webview`.

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -41,8 +41,8 @@ Generator.prototype.askFor = function askFor( argument ) {
     warning: 'You can change the permissions'
   },
   {
-    name: 'browserTagPermission',
-    message: 'Would you like to use the Browser Tag in your app',
+    name: 'webviewPermission',
+    message: 'Would you like to use the webview in your app',
     default: "Y/n",
     warning: 'You can change the permissions' 
   },
@@ -114,7 +114,7 @@ Generator.prototype.askFor = function askFor( argument ) {
     this.appPermissions.unlimitedStorage = (/y/i).test(props.unlimitedStoragePermission);
     this.appPermissions.usb = (/y/i).test(props.usbPermission);
     this.appPermissions.bluetooth = (/y/i).test(props.bluetoothPermission);
-    this.appPermissions.browserTag = (/y/i).test(props.browserTagPermission);
+    this.appPermissions.webview = (/y/i).test(props.webviewPermission);
     this.appPermissions.audioCapture = (/y/i).test(props.audioCapturePermission);
     this.appPermissions.videoCapture = (/y/i).test(props.videoCapturePermission);
     
@@ -150,8 +150,7 @@ Generator.prototype.buildData = function () {
   var experimental = {
     "bluetooth" : true,
     "usb": true,
-    "identity": true,
-    "browserTag": true
+    "identity": true
   };
 
   // Using object to maintain complex objects rather than strings.


### PR DESCRIPTION
Looking at the latest documentation for the chrome packaged apps it has a webview permission, nothing about a browser tag.

See http://developer.chrome.com/apps/app_external.html

Also, from the example browser app it does not look to need the experimental flag: https://github.com/GoogleChrome/chrome-app-samples/blob/master/browser/manifest.json
