### PR TITLE
Update Media Galleries ref to include delete

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -145,7 +145,7 @@ var Permissions = {
   'mediaGalleries': {
     availability: 'app',
     permission: {
-      'mediaGalleries': ['read', 'copyTo', 'allAutoDetected']
+      'mediaGalleries': ['read', 'delete', 'copyTo', 'allAutoDetected']
     }
   },
   'notifications': {

--- a/test/test-manifest.js
+++ b/test/test-manifest.js
@@ -65,7 +65,7 @@ describe('Chromeapp generator', function () {
       // fileSystem permission
       ['app/manifest.json', /\s+"fileSystem": \[\s+"write",\s+"retainEntries",\s+"directory"\s+\]/],
       // mediaGalleries permission
-      ['app/manifest.json', /\s+"mediaGalleries": \[\s+"read",\s+"copyTo",\s+"allAutoDetected"\s+\]/],
+      ['app/manifest.json', /\s+"mediaGalleries": \[\s+"read",\s+"delete",\s+"copyTo",\s+"allAutoDetected"\s+\]/],
       // socket permission
       ['app/manifest.json', /\s+"socket": \[\s+"tcp-connect:\*:\*",\s+"tcp-listen:\*:8080"\s+\]/]
     ];


### PR DESCRIPTION
Without delete, when adding a mediagalleries permissioned item to chrome you will get this error:
![image](https://cloud.githubusercontent.com/assets/2047962/4309716/24920bb6-3e9f-11e4-8063-0862eaa74ca5.png)
