### PR TITLE
Making it so that (dev) is not added to the manifest.json for permissions

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -296,7 +296,7 @@ manifest.prototype.setPermissions = function(newPerms) {
 
   _.each(newPerms, function(newPerm) {
     //Remove (dev) from new features
-    newPerm = (_.isString(newPerm) && newPerm.indexOf(' (dev)') > 0)  ? newPerm.substr(0,newPerm.indexOf(' (dev)')) : newPerm;
+    newPerm = newPerm.replace(' (dev)', '');
 
     // Determine which type of new permission
     var permDesc = _.isString(newPerm) ? Permissions[newPerm] : _.isObject(newPerm) && newPerm;


### PR DESCRIPTION
Chrome does not recognize permissions with (dev) on the end, so remove them.
![image](https://cloud.githubusercontent.com/assets/2047962/4311244/1e749466-3ead-11e4-9d16-9fb9b42acc3f.png)
