### PR TITLE
`.jshintrc`: remove deprecated options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,7 +10,5 @@
   "newcap": true,
   "noarg": true,
   "undef": true,
-  "strict": false,
-  "trailing": true,
-  "smarttabs": true
+  "strict": false
 }


### PR DESCRIPTION
Since JSHint v2.5 the `smarttabs` and `trailing` options are deprecated. https://github.com/jshint/jshint/releases/tag/2.5.0
